### PR TITLE
Test's throwable wasn't rethrow if deviceScreenshot fail.

### DIFF
--- a/allure-android/src/main/kotlin/ru/tinkoff/allure/android/Screenshot.kt
+++ b/allure-android/src/main/kotlin/ru/tinkoff/allure/android/Screenshot.kt
@@ -9,10 +9,14 @@ import java.util.concurrent.TimeUnit
  * @author Badya on 31.05.2017.
  */
 fun deviceScreenshot(tag: String) {
-    val file = createTempFile("attachment", null, Environment.getExternalStorageDirectory())
-    with(UiDevice.getInstance(getInstrumentation())) {
-        waitForIdle(TimeUnit.SECONDS.toMillis(5))
-        takeScreenshot(file)
+    try {
+        val file = createTempFile("attachment", null, Environment.getExternalStorageDirectory())
+        with(UiDevice.getInstance(getInstrumentation())) {
+            waitForIdle(TimeUnit.SECONDS.toMillis(5))
+            takeScreenshot(file)
+        }
+        AllureAndroidLifecycle.addAttachment(name = tag, type = "image/png", fileExtension = ".png", file = file)
+    }catch (e:Exception){
+        e.printStackTrace()
     }
-    AllureAndroidLifecycle.addAttachment(name = tag, type = "image/png", fileExtension = ".png", file = file)
 }


### PR DESCRIPTION
It may cause strange errors at test if we expect to catch this exception